### PR TITLE
fix: Correct YAML syntax error in buildspec.yml

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -44,7 +44,8 @@ phases:
       - echo "✅ HTML structure validation passed"
       
       - echo "5. CSS syntax validation..."
-      - node -e "
+      - |
+        node -e "
         const fs = require('fs');
         const css = fs.readFileSync('style.css', 'utf8');
         if (css.split('{').length !== css.split('}').length) {
@@ -52,7 +53,7 @@ phases:
           process.exit(1);
         }
         console.log('✅ CSS syntax validation passed');
-      "
+        "
       
       - echo "🏗️ Building static website..."
       - echo "Processing HTML files..."


### PR DESCRIPTION
- Fix multiline Node.js command syntax
- Use proper YAML literal block scalar (|)
- Resolve line 56 YAML parsing error