### PR TITLE
fix: Change Node.js runtime version from 18 to 12

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 18
+      nodejs: 12
     commands:
       - echo "=== INSTALL PHASE ==="
       - echo "Installing test dependencies..."


### PR DESCRIPTION
- CodeBuild image supports Node.js versions 10, 12 only
- Update runtime-versions to use nodejs: 12
- Resolve YAML_FILE_ERROR for unsupported Node.js version