### PR TITLE
fix: Revert to supported runtime versions for CodeBuild

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,8 +3,8 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 18
-      php: 8.1
+      nodejs: 12
+      php: 7.4
     commands:
       - echo "=== Installing dependencies ==="
       - echo "Node.js version:" && node --version


### PR DESCRIPTION
- Change Node.js from 18 to 12 (supported by amazonlinux2-x86_64-standard:3.0)
- Change PHP from 8.1 to 7.4 (supported by current CodeBuild image)
- Fix YAML_FILE_ERROR: Unknown runtime version

Error was: 'Unknown runtime version named 18 of nodejs. This build image has the following versions: 10, 12'